### PR TITLE
feat(projects): 새 프로젝트 생성 페이지 및 API 연동 구현

### DIFF
--- a/frontend/src/features/project/api/project.js
+++ b/frontend/src/features/project/api/project.js
@@ -4,3 +4,8 @@ export async function getProjects() {
   const res = await api.get('/projects');
   return res.data?.data ?? [];
 }
+
+export async function createProject({ name }) {
+  const res = await api.post('/projects', { name });
+  return res.data;
+}

--- a/frontend/src/pages/NewProject.jsx
+++ b/frontend/src/pages/NewProject.jsx
@@ -1,5 +1,143 @@
-function NewProject() {
-    return (<div>NewProject</div>);
+import { useState, useMemo } from 'react';
+import {
+    Box, Stack, Typography, TextField, Button, FormHelperText, Divider
+} from '@mui/material';
+import CloseRoundedIcon from '@mui/icons-material/CloseRounded';
+
+function NewProject({ onCreate }) {
+    const [name, setName] = useState('');
+    const [desc, setDesc] = useState('');
+    const MAX_DESC = 350;
+
+    const nameError =
+        name.trim().length === 0
+            ? ''
+            : name.trim().length < 2
+                ? '프로젝트 이름은 2자 이상이어야 합니다.'
+                : '';
+
+    const canSubmit = useMemo(() => {
+        return name.trim().length >= 2 && !nameError;
+    }, [name, nameError]);
+
+    const handleSubmit = (e) => {
+        e.preventDefault();
+        if (!canSubmit) return;
+        onCreate?.({
+            name: name.trim(),
+            description: desc.trim(),
+        });
+    };
+
+    return (
+        <Box
+            component="form"
+            onSubmit={handleSubmit}
+            sx={{
+                px: { xs: 2, md: 6 },
+                py: { xs: 6, md: 10 },
+                minHeight: 'calc(100vh - 64px)',
+                display: 'flex',
+                alignItems: 'flex-start',
+                justifyContent: 'center',
+            }}
+        >
+            <Stack
+                spacing={4}
+                sx={{
+                    width: '100%',
+                    maxWidth: 720,
+                }}
+            >
+                <Typography
+                    variant="h4"
+                    align="center"
+                    fontWeight={800}
+                    sx={{ mb: 2 }}
+                >
+                    Create a new project
+                </Typography>
+
+                <Divider sx={{ opacity: 0.15 }} />
+
+                <Stack spacing={1.5}>
+                    <Typography variant="h6" fontWeight={800}>
+                        Project name
+                    </Typography>
+                    <TextField
+                        value={name}
+                        onChange={(e) => setName(e.target.value)}
+                        placeholder=""
+                        fullWidth
+                        size="medium"
+                        error={!!nameError}
+                        sx={{
+                            '& .MuiOutlinedInput-root': {
+                                bgcolor: 'background.default',
+                            },
+                        }}
+                    />
+
+                    {nameError && (
+                        <Stack direction="row" alignItems="center" spacing={0.5}>
+                            <CloseRoundedIcon fontSize="small" sx={{ color: 'error.main' }} />
+                            <FormHelperText sx={{ color: 'error.main', ml: 0 }}>
+                                {nameError || '프로젝트 이름 검증 내용 출력'}
+                            </FormHelperText>
+                        </Stack>
+                    )}
+                </Stack>
+
+                <Stack spacing={1.5} sx={{ mt: 2 }}>
+                    <Typography variant="h6" fontWeight={800}>
+                        Description (optional)
+                    </Typography>
+
+                    <TextField
+                        value={desc}
+                        onChange={(e) => {
+                            const v = e.target.value;
+                            if (v.length <= MAX_DESC) setDesc(v);
+                        }}
+                        multiline
+                        minRows={6}
+                        fullWidth
+                        placeholder=""
+                        sx={{
+                            '& .MuiOutlinedInput-root': {
+                                bgcolor: 'background.default',
+                            },
+                        }}
+                        helperText={
+                            <Box sx={{ width: '100%', textAlign: 'right', opacity: 0.7 }}>
+                                {desc.length}/{MAX_DESC}
+                            </Box>
+                        }
+                    />
+                </Stack>
+
+                <Box sx={{ display: 'flex', justifyContent: 'center', mt: 2 }}>
+                    <Button
+                        type="submit"
+                        variant="contained"
+                        color="primary"
+                        size="large"
+                        disabled={!canSubmit}
+                        sx={{
+                            px: 4,
+                            py: 1.5,
+                            fontWeight: 800,
+                            borderRadius: 2,
+                            textTransform: 'none',
+                            minWidth: 260,
+                        }}
+                    >
+                        Create Project
+                    </Button>
+                </Box>
+            </Stack>
+        </Box>
+    );
 }
 
 export default NewProject;

--- a/frontend/src/pages/NewProject.jsx
+++ b/frontend/src/pages/NewProject.jsx
@@ -1,32 +1,53 @@
 import { useState, useMemo } from 'react';
-import {
-    Box, Stack, Typography, TextField, Button, FormHelperText, Divider
-} from '@mui/material';
+import { Box, Stack, Typography, TextField, Button, FormHelperText, Divider } from '@mui/material';
 import CloseRoundedIcon from '@mui/icons-material/CloseRounded';
+import { useNavigate } from 'react-router-dom';
+import { createProject } from '../features/project/api/project';
 
-function NewProject({ onCreate }) {
+function NewProject() {
+    const navigate = useNavigate();
+
     const [name, setName] = useState('');
     const [desc, setDesc] = useState('');
+    const [submitting, setSubmitting] = useState(false);
+    const [apiError, setApiError] = useState('');
+
     const MAX_DESC = 350;
 
-    const nameError =
+    const nameErrorClient =
         name.trim().length === 0
             ? ''
             : name.trim().length < 2
                 ? '프로젝트 이름은 2자 이상이어야 합니다.'
                 : '';
 
-    const canSubmit = useMemo(() => {
-        return name.trim().length >= 2 && !nameError;
-    }, [name, nameError]);
+    const nameError = apiError || nameErrorClient;
 
-    const handleSubmit = (e) => {
+    const canSubmit = useMemo(() => {
+        return !!name.trim() && !nameErrorClient && !submitting;
+    }, [name, nameErrorClient, submitting]);
+
+    const handleSubmit = async (e) => {
         e.preventDefault();
         if (!canSubmit) return;
-        onCreate?.({
-            name: name.trim(),
-            description: desc.trim(),
-        });
+
+        try {
+            setSubmitting(true);
+            setApiError('');
+
+            const res = await createProject({ name: name.trim() });
+            if (res?.success && res?.data?.id) {
+                navigate(`/project/${res.data.id}`);
+            } else {
+                setApiError('프로젝트 생성에 실패했습니다. 다시 시도해 주세요.');
+            }
+        } catch (err) {
+            const detail = err?.response?.data?.detail;
+            const message = detail?.message || '프로젝트 생성 중 오류가 발생했습니다.';
+            setApiError(message);
+        } finally {
+            setSubmitting(false);
+        }
     };
 
     return (
@@ -42,19 +63,8 @@ function NewProject({ onCreate }) {
                 justifyContent: 'center',
             }}
         >
-            <Stack
-                spacing={4}
-                sx={{
-                    width: '100%',
-                    maxWidth: 720,
-                }}
-            >
-                <Typography
-                    variant="h4"
-                    align="center"
-                    fontWeight={800}
-                    sx={{ mb: 2 }}
-                >
+            <Stack spacing={4} sx={{ width: '100%', maxWidth: 720 }}>
+                <Typography variant="h4" align="center" fontWeight={800} sx={{ mb: 2 }}>
                     Create a new project
                 </Typography>
 
@@ -66,23 +76,20 @@ function NewProject({ onCreate }) {
                     </Typography>
                     <TextField
                         value={name}
-                        onChange={(e) => setName(e.target.value)}
-                        placeholder=""
+                        onChange={(e) => {
+                            setName(e.target.value);
+                            if (apiError) setApiError('');
+                        }}
                         fullWidth
                         size="medium"
                         error={!!nameError}
-                        sx={{
-                            '& .MuiOutlinedInput-root': {
-                                bgcolor: 'background.default',
-                            },
-                        }}
+                        sx={{ '& .MuiOutlinedInput-root': { bgcolor: 'background.default' } }}
                     />
-
-                    {nameError && (
+                    {!!nameError && (
                         <Stack direction="row" alignItems="center" spacing={0.5}>
                             <CloseRoundedIcon fontSize="small" sx={{ color: 'error.main' }} />
                             <FormHelperText sx={{ color: 'error.main', ml: 0 }}>
-                                {nameError || '프로젝트 이름 검증 내용 출력'}
+                                {nameError}
                             </FormHelperText>
                         </Stack>
                     )}
@@ -102,17 +109,12 @@ function NewProject({ onCreate }) {
                         multiline
                         minRows={6}
                         fullWidth
-                        placeholder=""
-                        sx={{
-                            '& .MuiOutlinedInput-root': {
-                                bgcolor: 'background.default',
-                            },
-                        }}
                         helperText={
                             <Box sx={{ width: '100%', textAlign: 'right', opacity: 0.7 }}>
                                 {desc.length}/{MAX_DESC}
                             </Box>
                         }
+                        sx={{ '& .MuiOutlinedInput-root': { bgcolor: 'background.default' } }}
                     />
                 </Stack>
 
@@ -123,16 +125,9 @@ function NewProject({ onCreate }) {
                         color="primary"
                         size="large"
                         disabled={!canSubmit}
-                        sx={{
-                            px: 4,
-                            py: 1.5,
-                            fontWeight: 800,
-                            borderRadius: 2,
-                            textTransform: 'none',
-                            minWidth: 260,
-                        }}
+                        sx={{ px: 4, py: 1.5, fontWeight: 800, borderRadius: 2, textTransform: 'none', minWidth: 260 }}
                     >
-                        Create Project
+                        {submitting ? 'Creating...' : 'Create Project'}
                     </Button>
                 </Box>
             </Stack>


### PR DESCRIPTION
- 새 프로젝트 생성 페이지 레이아웃 추가
  - Project name, Description 입력 필드 구성
  - 프로젝트 이름 검증 에러 메시지 및 아이콘 표시
  - 설명 입력 시 글자 수 카운터(0/350) 표시
  - 중앙 정렬된 Create Project 버튼 추가

- 프로젝트 생성 API 연동
  - POST /api/v1/projects 호출 (name만 전송)
  - 생성 성공 시 응답 data.id 기반 상세 페이지로 라우팅
  - 이름 중복 시 서버 에러 메시지를 입력 필드 하단에 출력
  - 생성 버튼 로딩/비활성화 처리 및 UX 개선
  - Description은 현재 서버에 저장되지 않으므로 UI에만 유지